### PR TITLE
Fixed typo in long write methode.

### DIFF
--- a/proxy.js
+++ b/proxy.js
@@ -311,7 +311,7 @@ Proxy.prototype.isAllDiscovered = function() {
     } else {
     this._queueCommand(this.writeRequest(characteristic.valueHandle, data, false), function(data) {
         var opcode = data[0];
-        if (opcode === ATT_OP_WRITE_RESP*/) {
+        if (opcode === ATT_OP_WRITE_RESP) {
           this.emit('write', this._address, serviceUuid, characteristicUuid);
         }
       }.bind(this));


### PR DESCRIPTION
A remaining comment fragment in version 1.1.8 prevents **cmd_btlejuice_proxy.js** to start:
```
baumgartl@debian:/tmp/btlejuice/bin# nodejs cmd_btlejuice_proxy.js 
/tmp/btlejuice/proxy.js:314
        if (opcode === ATT_OP_WRITE_RESP*/) {
                                         ^
SyntaxError: Invalid regular expression: missing /
    at createScript (vm.js:56:10)
    at Object.runInThisContext (vm.js:97:10)
    at Module._compile (module.js:542:28)
    at Object.Module._extensions..js (module.js:579:10)
    at Module.load (module.js:487:32)
    at tryModuleLoad (module.js:446:12)
    at Function.Module._load (module.js:438:3)
    at Module.require (module.js:497:17)
    at require (internal/module.js:20:19)
    at Object.<anonymous> (/tmp/btlejuice/bin/cmd_btlejuice_proxy.js:14:13)
```